### PR TITLE
fix(paths): centralize path normalization across pipeline scripts

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -43,8 +43,11 @@ charset-normalizer==3.4.3
     # via
     #   requests
     #   scilex
+click==8.3.0
+    # via typer-slim
 colorama==0.4.6 ; sys_platform == 'win32'
     # via
+    #   click
     #   sphinx
     #   tqdm
 deprecated==1.2.18
@@ -60,15 +63,21 @@ fake-useragent==2.2.0
     # via
     #   scholarly
     #   scilex
+filelock==3.20.0
+    # via huggingface-hub
 free-proxy==1.1.3
     # via
     #   scholarly
     #   scilex
+fsspec==2025.12.0
+    # via huggingface-hub
 h11==0.16.0
     # via
     #   httpcore
     #   scilex
     #   wsproto
+hf-xet==1.2.0 ; platform_machine == 'AMD64' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'
+    # via huggingface-hub
 html5lib==1.1
     # via
     #   orcid
@@ -79,8 +88,11 @@ httpcore==1.0.9
     #   scilex
 httpx==0.27.2
     # via
+    #   huggingface-hub
     #   scholarly
     #   scilex
+huggingface-hub==1.2.1
+    # via scilex
 idna==3.10
     # via
     #   anyio
@@ -126,6 +138,7 @@ outcome==1.3.0.post0
     #   trio-websocket
 packaging==25.0
     # via
+    #   huggingface-hub
     #   scilex
     #   sphinx
     #   statsmodels
@@ -165,6 +178,10 @@ pytz==2025.2
     #   pandas
     #   scilex
 pyyaml==6.0.2
+    # via
+    #   huggingface-hub
+    #   scilex
+rapidfuzz==3.14.3
     # via scilex
 ratelimit==2.2.1
     # via scilex
@@ -196,6 +213,8 @@ selenium==4.35.0
     # via
     #   scholarly
     #   scilex
+shellingham==1.5.4
+    # via huggingface-hub
 simplejson==3.20.1
     # via
     #   orcid
@@ -273,7 +292,9 @@ threadpoolctl==3.6.0
     #   scikit-learn
     #   scilex
 tqdm==4.67.1
-    # via scilex
+    # via
+    #   huggingface-hub
+    #   scilex
 trio==0.30.0
     # via
     #   scilex
@@ -283,6 +304,8 @@ trio-websocket==0.12.2
     # via
     #   scilex
     #   selenium
+typer-slim==0.20.0
+    # via huggingface-hub
 types-python-dateutil==2.9.0.20250809
     # via
     #   arrow
@@ -290,9 +313,11 @@ types-python-dateutil==2.9.0.20250809
 typing-extensions==4.14.1
     # via
     #   beautifulsoup4
+    #   huggingface-hub
     #   scholarly
     #   scilex
     #   selenium
+    #   typer-slim
 tzdata==2025.2
     # via
     #   pandas

--- a/src/aggregate_collect.py
+++ b/src/aggregate_collect.py
@@ -28,7 +28,12 @@ from src.config_defaults import (
     DEFAULT_RELEVANCE_WEIGHTS,
     MIN_ABSTRACT_QUALITY_SCORE,
 )
-from src.constants import MISSING_VALUE, CitationFilterConfig, is_valid
+from src.constants import (
+    MISSING_VALUE,
+    CitationFilterConfig,
+    is_valid,
+    normalize_path_component,
+)
 from src.crawlers.aggregate import (
     ArxivtoZoteroFormat,
     DBLPtoZoteroFormat,
@@ -1389,12 +1394,12 @@ if __name__ == "__main__":
         main_config.get("aggregate_get_citations", True) and not args.skip_citations
     )
     output_dir = main_config.get("output_dir", DEFAULT_OUTPUT_DIR)
-    collect_name = main_config.get("collect_name")
+    collect_name = normalize_path_component(main_config.get("collect_name"))
     dir_collect = os.path.join(output_dir, collect_name)
-    # Get output filename from config, with fallback and handle leading slashes
-    output_filename = main_config.get(
-        "aggregate_file", DEFAULT_AGGREGATED_FILENAME
-    ).lstrip("/")
+    # Get output filename from config, with fallback and normalize path
+    output_filename = normalize_path_component(
+        main_config.get("aggregate_file", DEFAULT_AGGREGATED_FILENAME)
+    )
 
     # Path to config snapshot
     config_used_path = os.path.join(dir_collect, "config_used.yml")

--- a/src/constants.py
+++ b/src/constants.py
@@ -152,3 +152,33 @@ def safe_str(value, default: str = MISSING_VALUE) -> str:
     if is_missing(value):
         return default
     return str(value)
+
+
+def normalize_path_component(path_component: str) -> str:
+    """
+    Remove leading/trailing slashes from path components.
+
+    Ensures os.path.join() works correctly by preventing absolute path behavior
+    when config values mistakenly contain leading slashes (e.g., "/aggregated_results.csv").
+
+    Python's os.path.join() treats paths starting with "/" as absolute paths and
+    discards all previous path components. This function strips leading and trailing
+    slashes to ensure path components are always treated as relative paths.
+
+    Args:
+        path_component: Path component from config or user input
+
+    Returns:
+        str: Normalized path component without leading/trailing slashes
+
+    Examples:
+        >>> normalize_path_component("/aggregated_results.csv")
+        'aggregated_results.csv'
+        >>> normalize_path_component("collect_name/")
+        'collect_name'
+        >>> normalize_path_component("/dirname/")
+        'dirname'
+        >>> normalize_path_component("normal_path")
+        'normal_path'
+    """
+    return path_component.strip("/")

--- a/src/enrich_with_hf.py
+++ b/src/enrich_with_hf.py
@@ -37,7 +37,7 @@ import pandas as pd
 from tqdm import tqdm
 
 from src.config_defaults import DEFAULT_AGGREGATED_FILENAME, DEFAULT_OUTPUT_DIR
-from src.constants import MISSING_VALUE, is_valid
+from src.constants import MISSING_VALUE, is_valid, normalize_path_component
 from src.crawlers.utils import load_all_configs
 from src.HuggingFace.hf_client import HFClient
 from src.HuggingFace.metadata_extractor import MetadataExtractor
@@ -282,8 +282,10 @@ def main():
         # Load CSV
         output_dir = main_config.get("output_dir", DEFAULT_OUTPUT_DIR)
         aggregate_file = main_config.get("aggregate_file", DEFAULT_AGGREGATED_FILENAME)
-        collect_dir = os.path.join(output_dir, main_config["collect_name"])
-        csv_path = os.path.join(collect_dir, aggregate_file)
+        collect_dir = os.path.join(
+            output_dir, normalize_path_component(main_config["collect_name"])
+        )
+        csv_path = os.path.join(collect_dir, normalize_path_component(aggregate_file))
 
         logging.info(f"Loading CSV: {csv_path}")
         data = load_csv_with_auto_delimiter(csv_path)

--- a/src/export_to_bibtex.py
+++ b/src/export_to_bibtex.py
@@ -16,7 +16,7 @@ import pandas as pd
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from src.config_defaults import DEFAULT_AGGREGATED_FILENAME, DEFAULT_OUTPUT_DIR
-from src.constants import is_valid
+from src.constants import is_valid, normalize_path_component
 from src.crawlers.utils import load_all_configs
 
 # Configure logging
@@ -83,8 +83,10 @@ def load_aggregated_data(config: dict) -> pd.DataFrame:
     """
     output_dir = config.get("output_dir", DEFAULT_OUTPUT_DIR)
     aggregate_file = config.get("aggregate_file", DEFAULT_AGGREGATED_FILENAME)
-    dir_collect = os.path.join(output_dir, config["collect_name"])
-    file_path = os.path.join(dir_collect, aggregate_file)
+    dir_collect = os.path.join(
+        output_dir, normalize_path_component(config["collect_name"])
+    )
+    file_path = os.path.join(dir_collect, normalize_path_component(aggregate_file))
 
     logger.info(f"Loading data from: {file_path}")
 

--- a/src/push_to_zotero.py
+++ b/src/push_to_zotero.py
@@ -17,7 +17,7 @@ import pandas as pd
 from tqdm import tqdm
 
 from src.config_defaults import DEFAULT_AGGREGATED_FILENAME, DEFAULT_OUTPUT_DIR
-from src.constants import is_valid
+from src.constants import is_valid, normalize_path_component
 from src.crawlers.utils import load_all_configs
 from src.Zotero.zotero_api import ZoteroAPI, prepare_zotero_item
 
@@ -42,8 +42,10 @@ def load_aggregated_data(config: dict) -> pd.DataFrame:
     """
     output_dir = config.get("output_dir", DEFAULT_OUTPUT_DIR)
     aggregate_file = config.get("aggregate_file", DEFAULT_AGGREGATED_FILENAME)
-    dir_collect = os.path.join(output_dir, config["collect_name"])
-    file_path = os.path.join(dir_collect, aggregate_file)
+    dir_collect = os.path.join(
+        output_dir, normalize_path_component(config["collect_name"])
+    )
+    file_path = os.path.join(dir_collect, normalize_path_component(aggregate_file))
 
     logging.info(f"Loading data from: {file_path}")
 

--- a/tests/test_path_normalization.py
+++ b/tests/test_path_normalization.py
@@ -1,0 +1,110 @@
+"""Unit tests for path normalization utilities."""
+
+import sys
+from pathlib import Path
+
+# Add project root to path
+project_root = Path(__file__).parent.parent
+sys.path.insert(0, str(project_root))
+
+from src.constants import normalize_path_component  # noqa: E402
+
+
+def test_normalize_leading_slash():
+    """Test normalization of paths with leading slashes."""
+    assert normalize_path_component("/file.csv") == "file.csv"
+    assert (
+        normalize_path_component("/aggregated_results.csv") == "aggregated_results.csv"
+    )
+
+
+def test_normalize_trailing_slash():
+    """Test normalization of paths with trailing slashes."""
+    assert normalize_path_component("dirname/") == "dirname"
+    assert normalize_path_component("collect_name/") == "collect_name"
+
+
+def test_normalize_both_slashes():
+    """Test normalization of paths with both leading and trailing slashes."""
+    assert normalize_path_component("/dirname/") == "dirname"
+    assert normalize_path_component("/collect_20260114/") == "collect_20260114"
+
+
+def test_normalize_no_slashes():
+    """Test that normal paths are not modified."""
+    assert normalize_path_component("normal_path") == "normal_path"
+    assert (
+        normalize_path_component("aggregated_results.csv") == "aggregated_results.csv"
+    )
+
+
+def test_normalize_multiple_leading():
+    """Test normalization of paths with multiple leading slashes."""
+    assert normalize_path_component("///file.csv") == "file.csv"
+    assert normalize_path_component("////dirname") == "dirname"
+
+
+def test_normalize_multiple_trailing():
+    """Test normalization of paths with multiple trailing slashes."""
+    assert normalize_path_component("file.csv///") == "file.csv"
+    assert normalize_path_component("dirname////") == "dirname"
+
+
+def test_normalize_multiple_both():
+    """Test normalization of paths with multiple leading and trailing slashes."""
+    assert normalize_path_component("///file.csv///") == "file.csv"
+    assert normalize_path_component("////dirname////") == "dirname"
+
+
+def test_normalize_with_subdirs():
+    """Test that internal slashes are preserved."""
+    assert normalize_path_component("/path/to/file.csv") == "path/to/file.csv"
+    assert normalize_path_component("path/to/file.csv/") == "path/to/file.csv"
+    assert normalize_path_component("/path/to/file.csv/") == "path/to/file.csv"
+
+
+def test_normalize_empty_string():
+    """Test normalization of edge case: empty string."""
+    assert normalize_path_component("") == ""
+
+
+def test_normalize_only_slashes():
+    """Test normalization of edge case: only slashes."""
+    assert normalize_path_component("/") == ""
+    assert normalize_path_component("//") == ""
+    assert normalize_path_component("///") == ""
+
+
+if __name__ == "__main__":
+    """Run all tests when script is executed directly."""
+    import inspect
+
+    # Get all test functions
+    test_functions = [
+        (name, obj)
+        for name, obj in inspect.getmembers(sys.modules[__name__])
+        if inspect.isfunction(obj) and name.startswith("test_")
+    ]
+
+    print(f"Running {len(test_functions)} tests...\n")
+
+    passed = 0
+    failed = 0
+
+    for test_name, test_func in test_functions:
+        try:
+            test_func()
+            print(f"✓ {test_name}")
+            passed += 1
+        except AssertionError as e:
+            print(f"✗ {test_name}: {e}")
+            failed += 1
+        except Exception as e:
+            print(f"✗ {test_name}: Unexpected error: {e}")
+            failed += 1
+
+    print(f"\n{'=' * 60}")
+    print(f"Results: {passed} passed, {failed} failed")
+    print(f"{'=' * 60}")
+
+    sys.exit(0 if failed == 0 else 1)


### PR DESCRIPTION
  Add normalize_path_component() utility to handle config values with leading
  slashes, preventing os.path.join() path construction failures.

  Updated all pipeline scripts (enrich_with_hf, push_to_zotero, export_to_bibtex,
  aggregate_collect) to use centralized normalization. Added unit tests.

  Also synchronized requirements.txt with uv.lock (added huggingface-hub, rapidfuzz).